### PR TITLE
Kjellerbeistet v1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test_*.py
 # Midlertidige filer
 *.log
 *~
+
+# Lagrede spill
+/game/savegame.json

--- a/ENDRINGSLOGG.md
+++ b/ENDRINGSLOGG.md
@@ -6,6 +6,28 @@ Formatert etter [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.4.0] - 2025-09-##
+### Lagt til
+- Introdusert et poengsystem.
+    - Forskjellige handlinger gjennom spillet vil gi spilleren varierende antall poeng.
+    - Poengene printes kun når spilleren dør eller fullfører spillet.
+- Fire nye rom er også lagt til:
+    - 
+    - 
+    - 
+    - 
+
+### Endret
+- Lagt til en `se`-beskrivelse for ventil i rom 4 og rom 8 etter `status["åpen_ventil"]` er flippet
+
+### Fikset
+- Fikset logikken slik at den ekte nøkkelen brukes først dersom spiller har både ekte og falsk nøkkel i inventar i rom 4.
+
+### Fjernet
+- Det var teknisk sett mulig å bruke brekkjernet på vinduet i rom1, selv om spilleren aldri kan nå rom1 med brekkjernet i inventaret. Fjernet den relevante koden.
+
+---
+
 ## [1.3.2] - 2025-09-05
 ### Lagt til
 - Kommandoen `kart` viser en ASCII-versjon av rommene spilleren så langt har oppdaget.

--- a/ENDRINGSLOGG.md
+++ b/ENDRINGSLOGG.md
@@ -11,11 +11,7 @@ Formatert etter [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Introdusert et poengsystem.
     - Forskjellige handlinger gjennom spillet vil gi spilleren varierende antall poeng.
     - Poengene printes kun når spilleren dør eller fullfører spillet.
-- Fire nye rom er også lagt til:
-    - 
-    - 
-    - 
-    - 
+- Fire nye rom er også lagt til, rom12, rom13, kjeller2_1 og kjeller2_2.
 
 ### Endret
 - Lagt til en `se`-beskrivelse for ventil i rom 4 og rom 8 etter `status["åpen_ventil"]` er flippet.
@@ -23,6 +19,7 @@ Formatert etter [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fikset
 - Fikset logikken slik at den ekte nøkkelen brukes først dersom spiller har både ekte og falsk nøkkel i inventar i rom 4.
+- Skrivefeil: "dunts" -> "dunst"
 
 ### Fjernet
 - Det var teknisk sett mulig å bruke brekkjernet på vinduet i rom1, selv om spilleren aldri kan nå rom1 med brekkjernet i inventaret. Fjernet den relevante koden.

--- a/ENDRINGSLOGG.md
+++ b/ENDRINGSLOGG.md
@@ -18,7 +18,8 @@ Formatert etter [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - 
 
 ### Endret
-- Lagt til en `se`-beskrivelse for ventil i rom 4 og rom 8 etter `status["åpen_ventil"]` er flippet
+- Lagt til en `se`-beskrivelse for ventil i rom 4 og rom 8 etter `status["åpen_ventil"]` er flippet.
+- Oppdatert rombeskrivelse i rom6, rom8 (inkl. etter endring), rom9, rom10 og rom11 til å inkludere alle mulige utganger.
 
 ### Fikset
 - Fikset logikken slik at den ekte nøkkelen brukes først dersom spiller har både ekte og falsk nøkkel i inventar i rom 4.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kjellerbeistet
 
 **Forfatter:** AnBasement  
-**Versjon:** 1.3.2  
+**Versjon:** 1.4.0  
 **Lisens:** GNU GPLv3
 
 ---

--- a/game/engine.py
+++ b/game/engine.py
@@ -176,7 +176,8 @@ status = {
     "bøtte": False,
     "åpen_hylle": False,
     "hengelås": False,
-    "helse": 3
+    "helse": 3,
+    "poeng": 0
 }
 
 # Inventar

--- a/game/engine.py
+++ b/game/engine.py
@@ -73,6 +73,18 @@ rom10_inngang_tekst = (
 rom11_inngang_tekst = (
     "Du åpner døren og blir møtt av et bekmørkt rom. Lyset fra fyrrommet lyser ikke opp mer enn en meter inn."
 )
+rom12_inngang_tekst = (
+    "Du åpner døren til et trangt, kaldt rom. En svak lukt av mugg og gammel mat slår mot deg."
+)
+rom13_inngang_tekst = (
+    "Den smale åpningen leder inn i et fuktig, lavt kammer. De eneste lydene du hører er den konstante dryppingen fra det fuktige taket."
+)
+kjeller2_1_inngang_tekst = (
+    "Den bratte trappen ender i en mørk, kald del av kjelleren. Veggene er grov stein, og vann drypper fra taket."
+)
+kjeller2_2_inngang_tekst = (
+    "Du går inn i et rom som ser ut som en blanding av laboratorium og torturkammer."
+)
 
 # Tekst som vises ved "utforsk"-kommando
 rom1_utforsk_tekst = (
@@ -102,31 +114,50 @@ rom5_utforsk_tekst = (
 rom6_utforsk_tekst = (
     "Du står i noe som ligner på en vaskekjeller. Det står to vaskemaskiner stablet opp langs den ene veggen.\n"
     "Den bakre veggen og taket er fullt av rør, noen med små lekkasjer og andre så rustne at det er et under de ikke lekker. På ett av rørene er det et stort rødt hjul, og du legger merke til noe som ligner på en løs paneldør ved siden.\n"
-    "Langs den siste veggen står en rekke hyller med forskjellige vaskemidler på. En dør leder sør."
+    "Langs den siste veggen står en rekke hyller med forskjellige vaskemidler på. Dører leder sør og nord."
 )
 rom7_utforsk_tekst = (
     "Rommet minner om en vinkjeller for en tenåringsgutt. Langs veggene ligger store plastikksekker fylt med forskjellige tomme bokser med energidrikker.\n"
     "Du ser noen vinskap fylt med Red Bull og monster av forskjellige typer, og noe som ser ut som en fermenteringsbeholder som det står 'Monstervin' på.\n"
-    "På den ene veggen henger en stor oppslagstavle."
+    "På den ene veggen henger en stor oppslagstavle. En dør leder nord."
 )
 rom8_utforsk_tekst = (
     "Du står i det du bare kan anta er et gammeldags fyrrom basert på hva du har sett på film og TV. Midt i rommet står en gammel oljeovn.\n"
     "I taket knirker en rusten vifte i vei, og flere rør går fra oljeovnen og opp til forskjellige punkter i taket. Oljekanner står rundt om kring i rommet.\n"
-    "På østveggen er det en stor ventil."
+    "På østveggen er det en stor ventil. Dører leder nord og sør."
 )
 rom9_utforsk_tekst = (
     "Du står i et rom som ser ut til å ha vært hogget ut av steinen rundt kjelleren.\n"
     "Luften er tung og fuktig, og de grove veggene er dekket av noe som ser ut som glødende sopp. I et hjørne står en gammel bøtte med noe mørkt og flytende oppi.\n"
-    "Noen av soppene ser nesten ut til å ha ansikter på seg, men det kan vel ikke stemme?"
+    "Noen av soppene ser nesten ut til å ha ansikter på seg, men det kan vel ikke stemme? En dør leder sør."
 )
 rom10_utforsk_tekst = (
     "Rommet kan bare beskrives som et slags gammelt arkivrom. Stabler av gamle aviser, magasiner og blader og hyller med bøker over hele rommet.\n"
     "Midt i rommet står en pult med en gammel pizzaeske, en haug med avisutklipp og en slags manual på.\n"
-    "Du får inntrykk av at rommet ikke har hatt besøkende på lang tid."
+    "Du får inntrykk av at rommet ikke har hatt besøkende på lang tid. Dører leder vest og øst."
 )
 rom11_utforsk_tekst = (
     "Det mørke rommet er relativt tomt. Et tykt lag støv ligger på gulvet, avbrutt kun av fotspor som leder fem og tilbake mellom døren og en luke i gulvet.\n"
-    "Luken, som ser relativt solid ut, har et messingskilt på seg."
+    "Luken, som ser relativt solid ut, har et messingskilt på seg. En dør leder nord."
+)
+rom12_utforsk_tekst = (
+    "Rundt i rommet står en rekke hyller og kasser. Noen av kassene er ødelagte, og på gulvet ligger en pose med noe hvitt i. "
+    "På den ene veggen henger en jernkrok, og i et hjørne står en umerket krukke. " \
+    "Der er dører som leder vest og sør."
+)
+rom13_utforsk_tekst = (
+    "Kammeret har steinvegger som drypper vann, og gulvet er fuktig. "
+    "Rommet ser relativt tomt ut, sett bort fra en sokkel midt i rommet med et gammeldags skrin på." \
+    "Der en utgang som leder nord."
+)
+kjeller2_1_utforsk_tekst = (
+    "Du står i bunnen av stigen. I et hjørne står en gammeldags kasse malt i intrikate mønstre. "
+    "Veggene er grove og ser nesten ut til å være hogget ut manuelt, og du hører konstant sildring og drypping. "
+    "Til øst ser du en døråpning."
+)
+kjeller2_2_utforsk_tekst = (
+    "Rommet har et mørkt og trykkende preg. Nedstøvete bokhyller står langs veggene, og både gulvet og et bord er dekket i kolber i varierende stand. "
+    "På den ene veggen henger et slags verktøyskap fylt med ukjente instrumenter. Der er en dør som leder vest."
 )
 
 # Dict som kobler rom til utforsk-tekst
@@ -143,6 +174,10 @@ utforsk_tekster = {
     "rom9": rom9_utforsk_tekst,
     "rom10": rom10_utforsk_tekst,
     "rom11": rom11_utforsk_tekst,
+    "rom12": rom12_utforsk_tekst,
+    "rom13": rom13_utforsk_tekst,
+    "kjeller2_1": kjeller2_1_utforsk_tekst,
+    "kjeller2_2": kjeller2_2_utforsk_tekst,
 }
 
 # =========================
@@ -163,6 +198,10 @@ besøkt = {
     "rom9": False,
     "rom10": False,
     "rom11": False,
+    "rom12": False,
+    "rom13": False,
+    "kjeller2_1": False,
+    "kjeller2_2": False,
 }
 
 # Interagerbare objekter
@@ -176,6 +215,7 @@ status = {
     "bøtte": False,
     "åpen_hylle": False,
     "hengelås": False,
+    "luke_kode": False,
     "helse": 3,
     "poeng": 0
 }
@@ -186,7 +226,9 @@ inventar = {
     "har_nøkkel": False,
     "falsk_nøkkel": False,
     "glødende_sopp": False,
-    "kart": False
+    "kart": False,
+    "luke_nøkkel1": False,
+    "luke_nøkkel2": False,
 }
 
 # Gyldige valg i hvert rom

--- a/game/engine.py
+++ b/game/engine.py
@@ -147,17 +147,18 @@ rom12_utforsk_tekst = (
 )
 rom13_utforsk_tekst = (
     "Kammeret har steinvegger som drypper vann, og gulvet er fuktig. "
-    "Rommet ser relativt tomt ut, sett bort fra en sokkel midt i rommet med et gammeldags skrin på." \
+    "Rommet ser relativt tomt ut, sett bort fra en sokkel midt i rommet med et gammeldags skrin på. Det ser ut til at noen har risset noe inn i veggene. " \
     "Der en utgang som leder nord."
 )
 kjeller2_1_utforsk_tekst = (
-    "Du står i bunnen av stigen. I et hjørne står en gammeldags kasse malt i intrikate mønstre. "
+    "Du står i bunnen av stigen. En stige går langs den ene veggen, men ser ikke ut til å lede noe sted. "
     "Veggene er grove og ser nesten ut til å være hogget ut manuelt, og du hører konstant sildring og drypping. "
     "Til øst ser du en døråpning."
 )
 kjeller2_2_utforsk_tekst = (
-    "Rommet har et mørkt og trykkende preg. Nedstøvete bokhyller står langs veggene, og både gulvet og et bord er dekket i kolber i varierende stand. "
-    "På den ene veggen henger et slags verktøyskap fylt med ukjente instrumenter. Der er en dør som leder vest."
+    "Rommet har et trykkende preg. Nedstøvete bokhyller står langs veggene, og både gulvet og bordene er dekket med kolber i varierende stand. "
+    "På et bord står et gammelt treskrin med hengelås, tydelig tilsynelatende verdifullt. Langs den ene veggen er et verktøyskap. "
+    "En dør leder vest."
 )
 
 # Dict som kobler rom til utforsk-tekst
@@ -216,6 +217,10 @@ status = {
     "åpen_hylle": False,
     "hengelås": False,
     "luke_kode": False,
+    "åpen_luke": False,
+    "krukke": False,
+    "rom13_skrin": False,
+    "kolber": False,
     "helse": 3,
     "poeng": 0
 }
@@ -227,6 +232,8 @@ inventar = {
     "falsk_nøkkel": False,
     "glødende_sopp": False,
     "kart": False,
+    "saltpose": False,
+    "jernkrok": False,
     "luke_nøkkel1": False,
     "luke_nøkkel2": False,
 }
@@ -244,7 +251,11 @@ gyldige_valg_i_rom = {
     "rom8": ["nord", "øst", "ovn", "oljeovn", "vifte", "rør", "ventil", "oljekanner", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
     "rom9": ["sør", "sopp", "glødende sopp", "bøtte", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
     "rom10": ["vest", "aviser", "magasiner", "pult", "pizzaeske", "manual", "avisutklipp", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
-    "rom11": ["nord", "fotspor", "luke", "skilt", "messingskilt", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"]
+    "rom11": ["nord", "fotspor", "luke", "skilt", "messingskilt", "nøkkel", "kode", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
+    "rom12": ["øst", "sør", "hylle", "hyller", "kasse", "kasser", "filler", "stoffrester", "pose", "jernkrok", "krok", "krukke", "nøkkel", "gugge", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
+    "rom13": ["nord", "skrin", "sokkel", "vegg", "vegger", "brekkjern", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
+    "kjeller2_1": ["luke", "øst", "stige", "jernstige", "vegg", "vegger", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
+    "kjeller2_2": ["vest", "bokhylle", "bokhyller", "kolbe", "kolber", "skrin", "brekkjern", "utforsk", "hjelp", "tallkode", "lagre", "kart", "helse"],
 }
 
 # =========================

--- a/game/kartdata.py
+++ b/game/kartdata.py
@@ -1,21 +1,28 @@
 # All kode relatert til kartfunksjonen i spillet.
 import engine as en
 
-# Variabel med alle posisjonene for rommene
+# Dict med alle posisjonene for rommene i hovedetasjen
 romposisjoner = {
-    # Første kjelleretasje
-    "rom1":  {"pos": (8, 4), "trapper": False},
-    "rom2":  {"pos": (8, 8), "trapper": False},
-    "rom3":  {"pos": (6, 8), "trapper": False},
-    "rom4":  {"pos": (6, 4), "trapper": True},
-    "rom5":  {"pos": (2, 16), "trapper": False},
-    "rom6":  {"pos": (2, 0), "trapper": False},
-    "rom7":  {"pos": (6, 16), "trapper": False},
-    "rom8":  {"pos": (6, 0), "trapper": False},
-    "rom9":  {"pos": (0, 0), "trapper": False},
-    "rom10": {"pos": (2, 20), "trapper": False},
-    "rom11": {"pos": (8, 0), "trapper": True},
-    "gang1": {"pos": (4, 8), "trapper": False},
+    "rom1":  {"pos": (8, 8), "trapper": False},
+    "rom2":  {"pos": (8, 12), "trapper": False},
+    "rom3":  {"pos": (6, 12), "trapper": False},
+    "rom4":  {"pos": (6, 8), "trapper": True},
+    "rom5":  {"pos": (2, 20), "trapper": False},
+    "rom6":  {"pos": (2, 4), "trapper": False},
+    "rom7":  {"pos": (6, 20), "trapper": False},
+    "rom8":  {"pos": (6, 4), "trapper": False},
+    "rom9":  {"pos": (0, 4), "trapper": False},
+    "rom10": {"pos": (2, 24), "trapper": False},
+    "rom11": {"pos": (8, 4), "trapper": True},
+    "gang1": {"pos": (4, 12), "trapper": False},
+    "rom12": {"pos": (8, 0), "trapper": False},
+    "rom13": {"pos": (10, 0), "trapper": False},
+}
+
+# Dict med alle posisjonene for rommene i kjeller2
+kjeller2_posisjoner = {
+    "kjeller2_1": {"pos": (2, 4), "trapper": True},
+    "kjeller2_2": {"pos": (2, 8), "trapper": False},
 }
 
 # Kart for første etasje (rom1–rom11 + gang1)
@@ -27,52 +34,54 @@ def vis_kart():
     nåværende_rom = en.rom
     besøkt = en.besøkt
 
-    # Lag tomt kart med riktig antall rader og kolonner
-    rader = 9
-    kolonner = 24
+    # Automatisk velg etasje basert på hvilket rom spilleren er i
+    if nåværende_rom in romposisjoner:
+        rompos = romposisjoner
+        rader, kolonner = 11, 28
+        koblinger = [
+            ("rom1", "rom2"), ("rom2", "rom3"), ("rom3", "rom4"),
+            ("rom3", "gang1"), ("gang1", "rom5"), ("gang1", "rom6"),
+            ("gang1", "rom7"), ("gang1", "rom8"), ("rom5", "rom10"),
+            ("rom6", "rom9"), ("rom8", "rom11"), ("rom8", "rom4"),
+            ("rom11", "rom12"), ("rom12", "rom13")
+        ]
+    elif nåværende_rom in kjeller2_posisjoner:
+        rompos = kjeller2_posisjoner
+        rader, kolonner = 5, 20
+        koblinger = [
+            ("kjeller2_1", "kjeller2_2"),
+        ]
+    else:
+        print("Ingen kartdata for dette rommet.")
+        return
+
+    # Lag tomt kart
     kart_karakterer = [[" "]*kolonner for _ in range(rader)]
 
     # Rom som skal tegnes
-    synlige_rom = [rom for rom, _ in romposisjoner.items() if besøkt.get(rom, False) or rom == nåværende_rom]
+    synlige_rom = [rom for rom, _ in rompos.items() if besøkt.get(rom, False) or rom == nåværende_rom]
 
     # Tegn rom
     for rom in synlige_rom:
-        row, col = romposisjoner[rom]["pos"]
-        trapper = romposisjoner[rom].get("trapper", False)
-
+        row, col = rompos[rom]["pos"]
+        trapper = rompos[rom].get("trapper", False)
         if rom == nåværende_rom:
             symbol = "[x]"
         elif trapper:
             symbol = "[⇅]"
         else:
             symbol = "[ ]"
+        kart_karakterer[row][col:col+3] = list(symbol)
 
-        # Spesialhåndtering hubben (bred)
-        if rom == "gang1":
-            start = col - 8  # midten på 'g' som pos = 8
-            for i, s in enumerate("[        g        ]"):
-                kart_karakterer[row][start+i] = s
-        else:
-            kart_karakterer[row][col:col+3] = list(symbol)
-
-    # Koblinger mellom rom
-    koblinger = [
-        ("rom1", "rom2"), ("rom2", "rom3"), ("rom3", "rom4"),
-        ("rom3", "gang1"), ("gang1", "rom5"), ("gang1", "rom6"),
-        ("gang1", "rom7"), ("gang1", "rom8"), ("rom5", "rom10"),
-        ("rom6", "rom9"), ("rom8", "rom11"), ("rom8", "rom4")
-    ]
-
+    # Tegn koblinger
     for a, b in koblinger:
         if a in synlige_rom and b in synlige_rom:
-            row_a, col_a = romposisjoner[a]["pos"]
-            row_b, col_b = romposisjoner[b]["pos"]
+            row_a, col_a = rompos[a]["pos"]
+            row_b, col_b = rompos[b]["pos"]
 
-            # horisontal kobling
             if row_a == row_b:
                 for c in range(min(col_a, col_b)+3, max(col_a, col_b)):
                     kart_karakterer[row_a][c] = "-"
-            # vertikal kobling
             elif col_a == col_b:
                 for r in range(min(row_a, row_b)+1, max(row_a, row_b)):
                     kart_karakterer[r][col_a+1] = "|"

--- a/game/main.py
+++ b/game/main.py
@@ -2,7 +2,7 @@
 # eventyr.py
 #
 # Forfatter: AnBasement
-# Versjon: 1.3.2
+# Versjon: 1.4.0
 #
 # Beskrivelse:
 #   Et tekstbasert eventyrspill hvor spilleren navigerer gjennom flere rom

--- a/game/main.py
+++ b/game/main.py
@@ -73,4 +73,12 @@ while True:
     elif engine.rom == "rom10":
         engine.rom, engine.restart, engine.status, engine.besøkt = rooms.rom10(engine.rom, engine.restart, engine.status, engine.besøkt)
     elif engine.rom == "rom11":
-        engine.rom, engine.restart, engine.status, engine.besøkt = rooms.rom10(engine.rom, engine.restart, engine.status, engine.besøkt)
+        engine.rom, engine.restart, engine.status, engine.besøkt = rooms.rom11(engine.rom, engine.restart, engine.status, engine.besøkt)
+    elif engine.rom == "rom12":
+        engine.rom, engine.restart, engine.status, engine.besøkt = rooms.rom12(engine.rom, engine.restart, engine.status, engine.besøkt)
+    elif engine.rom == "rom13":
+        engine.rom, engine.restart, engine.status, engine.besøkt = rooms.rom13(engine.rom, engine.restart, engine.status, engine.besøkt)
+    elif engine.rom == "kjeller2_1":
+        engine.rom, engine.restart, engine.status, engine.besøkt = rooms.kjeller2_1(engine.rom, engine.restart, engine.status, engine.besøkt)
+    elif engine.rom == "kjeller2_2":
+        engine.rom, engine.restart, engine.status, engine.besøkt = rooms.kjeller2_2(engine.rom, engine.restart, engine.status, engine.besøkt)

--- a/game/rooms.py
+++ b/game/rooms.py
@@ -105,7 +105,7 @@ def rom2_ost(restart):
                 "Plutselig kommer en lang arm ut av døren, som klorer etter deg. Du smeller døren igjen på armen, som trekker seg tilbake og lar deg lukke døren. "
                 f"Du mister 1 helsepoeng. Nå har du {engine.status['helse']} helse."
             )
-            break
+            return False, "rom2"
         elif svar == "nei":
             return False, "rom2"
         else:
@@ -149,12 +149,12 @@ def rom3(rom, restart, status, besøkt):
                 continue
 
             if item == "brekkjern" and target == "malingsspann":
-                if not engine.inventar["har_nøkkel"]:
+                if not engine.inventar["luke_nøkkel1"]:
                     print(
                         "Du bruker det lille brekkjernet du fant til å åpne malingsspannet som hadde noe inni seg.\n"
                         "Inni finner du en gammeldags nøkkel!"
                     )
-                    engine.inventar["har_nøkkel"] = True
+                    engine.inventar["luke_nøkkel1"] = True
                     status["poeng"] += 100
                 else:
                     print("Malingsspannene er tomme nå.")
@@ -168,13 +168,13 @@ def rom3(rom, restart, status, besøkt):
 # Funksjon for malingsspann i rom 3
 def rom3_malingsspann(status, verb):
     if verb == "se":
-        if not engine.inventar["har_nøkkel"]:
+        if not engine.inventar["luke_nøkkel1"]:
             print("En haug med gamle malingsspann.")
         else:
             print("Et sett gamle malingsspann, men de er tomme nå.")
 
     elif verb == "ta":
-        if not engine.inventar["har_nøkkel"]:
+        if not engine.inventar["luke_nøkkel1"]:
             print(
                 "Du plukker opp noen av malingsspannene, og hører noe løst inni et av dem.\n"
                 "Du forsøker å åpne det, men inntørket maling og rust har gjort det nesten umulig."
@@ -518,7 +518,7 @@ def rom8(rom, restart, status, besøkt):
                 status["poeng"] += 150
                 engine.rom8_utforsk_tekst = ("Du står i det du bare kan anta er et gammeldags fyrrom basert på hva du har sett på film og TV. Midt i rommet står en gammel oljeovn.\n" \
                 "I taket knirker en rusten vifte i vei, og flere rør går fra oljeovnen og opp til forskjellige punkter i taket. Oljekanner står rundt om kring i rommet.\n" \
-                "På østveggen er det en stor åpning."
+                "På østveggen er det en stor åpning. Dører leder nord og sør."
                 )
                 engine.rom4_utforsk_tekst = ("I midten av rommet står en trapp opp til etasjen over. Du ser en dør i enden av trappen.\n" \
                 "Under trappen står et gammelt skrivebord med en stol. På vestveggen er det et åpent hull.\n"
@@ -595,6 +595,9 @@ def rom10(rom, restart, status, besøkt):
             if obj == "vest":
                 rom = "rom5"
                 break
+            elif obj == "øst":
+                rom = "rom12"
+                break
             else:
                 print(engine.ingen_vei)
 
@@ -634,6 +637,46 @@ def rom11(rom, restart, status, besøkt):
         if verb == "gå":
             if obj == "nord":
                 rom = "rom8"
+                break
+            else:
+                print(engine.ingen_vei)
+        
+        elif verb == "se":
+            if obj == "fotspor":
+                print("Fotsporene leder frem og tilbake mellom luken og døren, og ser relativt ferske ut sammenlignet med resten av rommet.")
+            elif obj == "luke":
+                print("Luken er låst med ikke bare én, men tre hengelåser. To trenger en nøkkel, og den tredje trenger en 4-sifret kode. Du forsøker å dra i den, uten hell.")
+            elif obj in ["skilt", "messingskilt"]:
+                print("Du tørker litt støv og rusk av messingskiltet og leser det. 'ADGANG KUN FOR ALFAMENN!!'")
+            else:
+                print(engine.ugyldig)
+
+        elif verb == "ta":
+            if obj == "fotspor":
+                print("Du forsøker å samle sammen støvet rundt fotsporet før du tar deg selv i å lure på hva du holder på med.")
+            elif obj == "luke":
+                print("Du river og sliter litt i luken uten hell.")
+            elif obj in ["skilt", "messingskilt"]:
+                print("Du prøver å pirke opp skiltet, men får ikke grep.")
+
+        else:
+            print(engine.ugyldig)
+            
+    return rom, restart, status, besøkt
+    
+# Funksjon for rom 12
+def rom12(rom, restart, status, besøkt):
+    besøkt = engine.rombeskrivelse("rom12", engine.rom12_inngang_tekst, engine.rom12_utforsk_tekst, besøkt)
+
+    while True:  
+        verb, obj = engine.parse_kommando()
+        
+        if verb == "gå":
+            if obj == "øst":
+                rom = "rom11"
+                break
+            if obj == "sør":
+                rom = "rom13"
                 break
             else:
                 print(engine.ingen_vei)

--- a/game/rooms.py
+++ b/game/rooms.py
@@ -30,16 +30,9 @@ def rom1(rom, restart, besøkt):
                     break
                 elif valg == "nei":
                     break
+
                 else:
                     print(engine.ugyldig)
-
-        elif verb == "bruk" and isinstance(obj, tuple):
-            item, target = obj
-            if item == "brekkjern" and target == "vindu":
-                print("Du prøver å bruke brekkjernet på vinduet, men det sitter for hardt.")
-
-            else:
-                print(f"Kan ikke bruke {item} på {target}, men det fungerer ikke her.")
 
     return rom, restart, besøkt
 
@@ -79,6 +72,7 @@ def rom2(rom, restart, status, besøkt):
             if obj == "hammer" and not status["har_hammer"]:
                 print("Idet du plukker opp hammeren, smuldrer treskaftet opp...")
                 status["har_hammer"] = True
+                status["poeng"] += 10
             else:
                 print(engine.ugyldig)
 
@@ -143,6 +137,7 @@ def rom3(rom, restart, status, besøkt):
             elif obj == "bokser":
                 print("En haug med det som ser ut til å en gang ha vært pappesker, alle merket med tallet '4', men er nå en haug med forråtnende papp.")
                 status["tall1"] = True
+                status["poeng"] += 25
             else:
                 print(engine.ugyldig)
 
@@ -160,6 +155,7 @@ def rom3(rom, restart, status, besøkt):
                         "Inni finner du en gammeldags nøkkel!"
                     )
                     engine.inventar["har_nøkkel"] = True
+                    status["poeng"] += 100
                 else:
                     print("Malingsspannene er tomme nå.")
             else:
@@ -216,7 +212,7 @@ def rom4(rom, restart, status, besøkt):
                 if not status["åpen_ventil"]:
                     print("En stor ventil er plassert midt på vestveggen. Det kommer varm luft fra den andre siden.")
                 else:
-                    print(engine.ugyldig)
+                    print("Ventilen står lent mot veggen ved siden av den nye åpningen i veggen.")
             elif obj == "trapp":
                 print("En gammel, morken trapp. Du ser en dør i toppen av trappen.")
             elif obj == "dør":
@@ -246,6 +242,7 @@ def rom4(rom, restart, status, besøkt):
                         print("Med riktig kode får du av hengelåsen. Oppi skuffen ligger et brekkjern, som du plukker opp.")
                         engine.inventar["brekkjern"] = True
                         engine.status["hengelås"] = True
+                        engine.status["poeng"] += 250
                         break
                     else:
                         print("Feil kode. Prøv igjen.")
@@ -253,7 +250,21 @@ def rom4(rom, restart, status, besøkt):
         elif verb == "bruk" and isinstance(obj, tuple):
             item, target = obj
             if item == "nøkkel" and target == "dør":
-                if engine.inventar["falsk_nøkkel"]:
+                if engine.inventar["har_nøkkel"]:
+                    print("Du klatrer opp til døren i toppen av trappen, og setter den gamle nøkkelen i nøkkelhullet.\n"
+                    "Du hører et tydelig *klikk* når du vrir den. Med noe makt klarer du å vri om håndtaket, åpne døren, og rømme ut av kjelleren.\n"
+                    "Gratulerer! Du har unngått Kjellerbeistet og rømt fra kjelleren!")
+                    engine.status["poeng"] += 1000
+                    print(f"Du fullførte spillet med {engine.status["poeng"]} poeng!")
+                    while True:
+                        valg_restart = input(engine.omstart).strip().lower()
+                        if valg_restart == "ja":
+                            return True, "rom1", status, besøkt
+                        elif valg_restart == "nei":
+                            quit()
+                        else:
+                            print(engine.ugyldig)
+                elif engine.inventar["falsk_nøkkel"]:
                     engine.endre_helse(-1)
                     print(
                     "Med litt makt klarer du å presse nøkkelen du fant inn i nøkkelhullet.\n"
@@ -261,19 +272,8 @@ def rom4(rom, restart, status, besøkt):
                     "Du ramler ned trappen og slår deg grundig på vei ned."
                     f"Du mister 1 helsepoeng. Nå har du {engine.status['helse']} helse."
                     )
-                    break
-                elif engine.inventar["har_nøkkel"]:
-                    print("Du klatrer opp til døren i toppen av trappen, og setter den gamle nøkkelen i nøkkelhullet.\n"
-                    "Du hører et tydelig *klikk* når du vrir den. Med noe makt klarer du å vri om håndtaket, åpne døren, og rømme ut av kjelleren.\n"
-                    "Gratulerer! Du har unngått Kjellerbeistet og rømt fra kjelleren!")
-                while True:
-                    valg_restart = input(engine.omstart).strip().lower()
-                    if valg_restart == "ja":
-                        return True, "rom1", status, besøkt
-                    elif valg_restart == "nei":
-                        quit()
-                    else:
-                        print(engine.ugyldig)
+                else:
+                    print(engine.ugyldig)
 
         else:
             print(engine.ugyldig)
@@ -340,12 +340,14 @@ def rom5(rom, restart, status, besøkt):
                 print("Bakerst i rommet står det et skap som minner deg om skoledagene dine. Sett bort fra tallet '7' på forsiden er det ingenting uvanlig med det.\n" \
                 "Du tar tak i håndtaket og røsker til, men skapdøren beveger seg ikke.")
                 status["tall2"] = True
+                status["poeng"] += 25
             elif obj in ["hylle", "hyller"]:
                 while True:
                     svar = input("Du undersøker hyllen på østveggen litt nærmere, og merker en underlig lukt fra dem. Ved nærmere undersøkelse ser du en dør bak hyllen. Vil du forsøke å flytte på den? \n> ").strip().lower()
                     if svar == "ja":
                         print("Du dytter så hardt du kan i siden av hyllen, som etterhvert begynner å skli til siden. Bak finner du en åpenbart hjemmesnekret dør.")
                         status["åpen_hylle"] = True
+                        status["poeng"] += 100
                         engine.rom5_utforsk_tekst = (
                             "Du finner deg omringet av høye stabler av kasser og esker. "
                             "To høye reoler står midt i rommet, og langs den bakre veggen står et enkelt skap. "
@@ -388,6 +390,7 @@ def rom6(rom, restart, status, besøkt):
             elif verb == "hyller":
                 print("Du ser fort over hyllene etter noe som kan hjelpe deg, men ser stort sett bare forskjellige vaskemidler av merket '2MO'.")
                 status["tall3"] = True
+                status["poeng"] += 25
             elif obj in ["rør", "hjul"]:
                 svar = input("Det største av rørene har et rødt hjul festet til seg. Du tar borti røret, og kan kjenne at det beveger seg vann gjennom det. Vil du vri på hjulet? (ja/nei) ").lower().strip()
                 if svar == "ja":
@@ -430,7 +433,7 @@ def rom7(rom, restart, status, besøkt):
             elif obj == "oppslagstavle":
                 print("Det henger et par forskjellige lapper på oppslagstavlen som ser ut til å indikere datoer på tidligere og det nåværende fermenteringsprosjektet.\n" \
                     "På en gul lapp står det '!NB! Esker, skap, såpe!'")
-                
+                engine.status["poeng"] += 10
         elif verb == "ta":
             if obj == "plastsekker":
                 print("Du plukker opp en plastsekk, som umiddelbart revner.")
@@ -479,7 +482,10 @@ def rom8(rom, restart, status, besøkt):
             elif obj == "oljekanner":
                 print("Et par oljekanner er strødd rundt rommet, noen ser eldre ut enn andre.")
             elif obj == "ventil":
-                print("En stor ventil. Du forsøker å kikke gjennom og tror du ser et annet rom på andre siden.")
+                if not status["åpen_ventil"]:
+                    print("En stor ventil. Du forsøker å kikke gjennom og tror du ser et annet rom på andre siden.")
+                else:
+                    print("Det er en stor åpning i veggen hvor ventilen var før. Selve ventilen ligger lent opp mot veggen på andre siden.")
             else:
                 print(engine.ugyldig)
 
@@ -509,6 +515,7 @@ def rom8(rom, restart, status, besøkt):
                 print("Du presser brekkjernet inn i en glipe på den ene siden av ventilen og røsker godt til.\n" \
                       "Ventilen faller i gulvet med et voldsomt smell, og på den andre siden ser du et rom med en trapp.")
                 status["åpen_ventil"] = True
+                status["poeng"] += 150
                 engine.rom8_utforsk_tekst = ("Du står i det du bare kan anta er et gammeldags fyrrom basert på hva du har sett på film og TV. Midt i rommet står en gammel oljeovn.\n" \
                 "I taket knirker en rusten vifte i vei, og flere rør går fra oljeovnen og opp til forskjellige punkter i taket. Oljekanner står rundt om kring i rommet.\n" \
                 "På østveggen er det en stor åpning."
@@ -551,6 +558,7 @@ def rom9(rom, restart, status, besøkt):
             if obj in ["sopp", "glødende sopp"]:
                 print("Du tar tak i en av soppene og napper til. Gratulerer, du har en glødende sopp! Kanskje best å ikke smake på...")
                 status["glødende_sopp"] = True
+                status["poeng"] += 50
             elif obj == "bøtte":
                 if not status["bøtte"]:
                     svar = input("Du nærmer deg bøtten og kjenner en illeluktende dunts som gjør det litt vanskelig å puste. Plutselig virker guggen litt innbydende. Vil du smake? (ja/nei) " )
@@ -560,6 +568,7 @@ def rom9(rom, restart, status, besøkt):
                         "Når du setter bøtten ned igjen faller bunnen ut, og guggen renner utover gulvet.\n" \
                         f"Du får 1 helsepoeng, og har nå {engine.status['helse']}.")
                         status["bøtte"] = True
+                        status["poeng"] += 200
                         engine.rom9_utforsk_tekst = ("Du står i et rom som ser ut til å ha vært hogget ut av steinen rundt kjelleren.\n" \
                         "Luften er tung og fuktig, og de grove veggene er dekket av noe som ser ut som glødende sopp. I et hjørne er det en stor pytt med mørk gugge.\n" \
                         "Noen av soppene ser nesten ut til å ha ansikter på seg, men det kan vel ikke stemme?"
@@ -600,6 +609,7 @@ def rom10(rom, restart, status, besøkt):
                 if not engine.inventar["kart"]:
                     print("Du blåser støvet av den gamle pizzaesken og plukker den opp. På undersiden ser du noe som ligner på et slags kart over kjelleren. Du river det løs og tar det med deg.")
                     engine.inventar["kart"] = True
+                    engine.status["poeng"] += 500
                 else:
                     print("En pizzaeske med et hull hvor det tidligere var et kart.")
             elif obj == "manual":

--- a/game/rooms.py
+++ b/game/rooms.py
@@ -561,7 +561,7 @@ def rom9(rom, restart, status, besøkt):
                 status["poeng"] += 50
             elif obj == "bøtte":
                 if not status["bøtte"]:
-                    svar = input("Du nærmer deg bøtten og kjenner en illeluktende dunts som gjør det litt vanskelig å puste. Plutselig virker guggen litt innbydende. Vil du smake? (ja/nei) " )
+                    svar = input("Du nærmer deg bøtten og kjenner en illeluktende dunst som gjør det litt vanskelig å puste. Plutselig virker guggen litt innbydende. Vil du smake? (ja/nei) " )
                     if svar == "ja":
                         engine.endre_helse(+1)
                         print("Du holder deg for nesen og tar forsiktig en slurk. Guggen er overraskende søt, og du får en god, varm følelse i magen.\n" \
@@ -638,6 +638,12 @@ def rom11(rom, restart, status, besøkt):
             if obj == "nord":
                 rom = "rom8"
                 break
+            if obj == "luke":
+                if not engine.status["åpen_luke"]:
+                    print(engine.ugyldig)
+                else:
+                    rom = "kjeller2_1"
+                    break
             else:
                 print(engine.ingen_vei)
         
@@ -658,6 +664,24 @@ def rom11(rom, restart, status, besøkt):
                 print("Du river og sliter litt i luken uten hell.")
             elif obj in ["skilt", "messingskilt"]:
                 print("Du prøver å pirke opp skiltet, men får ikke grep.")
+            
+        elif verb == "bruk" and isinstance(obj, tuple):
+            item, target = obj
+            if item in ["nøkkel", "kode"] and target == "luke":
+                if engine.status["åpen_luke"]:
+                    print("Luken er allerede åpnet.")
+                elif not engine.status["luke_kode"]:
+                    print("Du mangler koden til kodelåsen.")
+                elif not engine.inventar["luke_nøkkel1"]:
+                    print("Du mangler nøkkelen til den første låsen.")
+                elif not engine.inventar["luke_nøkkel2"]:
+                    print("Du mangler nøkkelen til den andre låsen.")
+                else:
+                    print("Med de to nøklene og koden til hengelåsen får du åpnet luken.")
+                    engine.status["åpen_luke"] = True
+                    engine.status["poeng"] += 500
+            else:
+                print(engine.ugyldig)
 
         else:
             print(engine.ugyldig)
@@ -682,24 +706,174 @@ def rom12(rom, restart, status, besøkt):
                 print(engine.ingen_vei)
         
         elif verb == "se":
-            if obj == "fotspor":
-                print("Fotsporene leder frem og tilbake mellom luken og døren, og ser relativt ferske ut sammenlignet med resten av rommet.")
-            elif obj == "luke":
-                print("Luken er låst med ikke bare én, men tre hengelåser. To trenger en nøkkel, og den tredje trenger en 4-sifret kode. Du forsøker å dra i den, uten hell.")
-            elif obj in ["skilt", "messingskilt"]:
-                print("Du tørker litt støv og rusk av messingskiltet og leser det. 'ADGANG KUN FOR ALFAMENN!!'")
+            if obj in ["hylle", "hyller"]:
+                print("Hyllene er fulle av diverse hermetikk. Du merker at det er overraskende mange kanner med fersken.")
+            elif obj in ["kasse", "kasser"]:
+                print("Du kikker over kassene, og ser at en av dem er åpnet. Du ser en haug med filler og stoffrester i bunnen.")
+            elif obj in ["filler", "stoffrester"]:
+                print("Det ligger stoffrester og filler i forskjellige kasser i den ene kassen. Du romsterer litt rundt og ser en liten nøkkel i bunnen.")
+            elif obj == "pose":
+                print("Når du ser litt nærmere etter ser du at det hvite stoffet ser ut som om det enten er salt eller sukker.")
+            elif obj in ["jernkrok", "krok"]:
+                print("En gammel jernkrok som henger på veggen. Den ser litt løs ut. Vil helst ikke tenke på hva den er blitt brukt til...")
+            elif obj == "krukke":
+                print("Du nærmer deg krukken og ser oppi. En mørk gugge med en litt søt eim fyller den til randen.")
             else:
                 print(engine.ugyldig)
 
         elif verb == "ta":
-            if obj == "fotspor":
-                print("Du forsøker å samle sammen støvet rundt fotsporet før du tar deg selv i å lure på hva du holder på med.")
-            elif obj == "luke":
-                print("Du river og sliter litt i luken uten hell.")
-            elif obj in ["skilt", "messingskilt"]:
-                print("Du prøver å pirke opp skiltet, men får ikke grep.")
+            if obj == "nøkkel":
+                print("Du rekker hånden ned i stoffrestene og plukker opp nøkkelen. Det henger en liten lapp på den hvor det står 'K2'.")
+                engine.inventar["luke_nøkkel2"] = True
+                engine.status["poeng"] += 200
+            elif obj == "pose":
+                print("Du plukker opp posen og åpner den. Du tar litt av det hvite pulveret på fingen og smaker det. Salt? Jaja, kanskje det blir nyttig.")
+                engine.inventar["saltpose"] = True
+                engine.status["poeng"] += 50
+            elif obj in ["krok", "jernkrok"]:
+                print("Du røsker litt i jernkroken på veggen, som løsner lett, og henger den på beltet ditt.")
+                engine.inventar["jenrkrok"] = True
+                engine.status["poeng"] += 100
+            elif obj in ["krukke", "gugge"]:
+                if not engine.inventar["krukke"]:
+                    engine.endre_helse(-1)
+                    print("Du tar en sjanse og lener deg ned over krukken. Du smaker litt på guggen, og kjenner umiddelbart at du blir litt ør i hodet.\n" \
+                    f"Du mister 1 helsepoeng, og har nå {engine.status['helse']}.")
+                    engine.status["krukke"] = True
+                    engine.status["poeng"] -= 50
+                else:
+                    print("Tror ikke det er en god ide å teste den guggen igjen...")
+            else:
+                print(engine.ugyldig)
 
         else:
             print(engine.ugyldig)
             
     return rom, restart, status, besøkt
+
+# Funksjon for rom 13
+def rom13(rom, restart, status, besøkt):
+    besøkt = engine.rombeskrivelse("rom13", engine.rom13_inngang_tekst, engine.rom13_utforsk_tekst, besøkt)
+
+    while True:  
+        verb, obj = engine.parse_kommando()
+        
+        if verb == "gå":
+            if obj == "nord":
+                rom = "rom12"
+                break
+            else:
+                print(engine.ingen_vei)
+        
+        elif verb == "se":
+            if obj == "skrin":
+                print("Et gammelt skrin med intrikate mønstre skåret inn i treverket.")
+            elif obj == "sokkel":
+                print("Litt merkelig å se en sokkel som kanskje ser ut som den hører hjemme i et herskapshus i en fuktig kjeller...")
+            elif obj in ["vegg", "vegger"]:
+                print("Du undersøker veggene litt, og merker deg at det ikke ser ut som en profesjonell har laget dette rommet. Du merker at de samme fire tallene er risset inn flere steder: \n" \
+                "'3142'.")
+                engine.status["luke_kode"] = True
+                engine.status["poeng"] += 150
+            else:
+                print(engine.ugyldig)
+            
+        elif verb == "ta":
+            if obj == "skrin":
+                print("Du forsøker å løfte opp skrinet, men det ser ut til å være helt boltet fast i sokkelen.")
+            else:
+                print(engine.ugyldig)
+            
+        elif verb == "bruk" and isinstance(obj, tuple):
+            item, target = obj
+            if item == "brekkjern" and target == "skrin":
+                print("Du klarer å presse brekkjernet inn i en liten sprekk og drar til med all din makt. \n"
+                      "Selv etter et minutt med kaving klarer du ikke å få opp skrinet.")
+                engine.status["poeng"] += 50
+            else:
+                print(engine.ugyldig)
+        
+        else:
+            print(engine.ugyldig)
+            
+    return rom, restart, status, besøkt
+
+# Funksjon for kjeller2_1
+def kjeller2_1(rom, restart, status, besøkt):
+    besøkt = engine.rombeskrivelse("kjeller2_1", engine.kjeller2_1_inngang_tekst, engine.kjeller2_1_utforsk_tekst, besøkt)
+
+    while True:  
+        verb, obj = engine.parse_kommando()
+        
+        if verb == "gå":
+            if obj == "luke":
+                rom = "rom11"
+                break
+            if obj == "øst":
+                rom = "kjeller2_2"
+                break
+            else:
+                print(engine.ingen_vei)
+        
+        elif verb == "se":
+            if obj in ["stige", "jernstige"]:
+                print("Du tusler bort til stigen og klør deg litt i hodet. En stige, festet i veggen, som ikke går noe sted? Merkelig. Den er uansett alt for glatt og fuktig til å klatre.")
+            elif obj in ["vegg", "vegger"]:
+                print("Det virker åpenbart at dette rommet har blitt hogget ut manuelt, og ikke med fokus på estetikk.")
+            else:
+                print(engine.ugyldig)
+        
+        else:
+            print(engine.ugyldig)
+
+    return rom, restart, status, besøkt
+
+# Funksjon for kjeller2_2
+def kjeller2_2(rom, restart, status, besøkt):
+    besøkt = engine.rombeskrivelse("kjeller2_2", engine.kjeller2_2_inngang_tekst, engine.kjeller2_2_utforsk_tekst, besøkt)
+
+    while True:  
+        verb, obj = engine.parse_kommando()
+        
+        if verb == "gå":
+            if obj == "vest":
+                rom = "kjeller2_1"
+                break
+            else:
+                print(engine.ingen_vei)
+
+        elif verb == "se":
+            if obj in ["bokhylle", "bokhyller"]:
+                print("Du går opp og ned langs bokhyllene og skummer over titlene. Underlig mange handler om anatomi. Det ligger også noen notatbøker her med forskjellige årstall på.")
+            elif obj in ["kolbe", "kolber"]:
+                print("De fleste kolbene er knust og nedstøvet. Noen ser ut til å ha blitt håndtert litt nyligere, noen med litt væske i bunnen.")
+            elif obj == "skrin":
+                print("Et gammelt treskrin med en hengelås på.")
+            else:
+                print(engine.ugyldig)
+        
+        elif verb == "ta":
+            if obj in ["kolbe", "kolber"]:
+                if not engine.status["kolber"]:
+                    engine.endre_helse(-1)
+                    print("Du går litt mellom de forskjellige kolbene. De fleste er knust, men du ser en på gulvet som har en slags sølvfarget væske oppi. Du bøyer deg ned og plukker den opp, men kolben knuser idet du tar på den.\n" \
+                    f"Du mister 1 helsepoeng, og har nå {engine.status['helse']}.")
+                    engine.status["kolber"] = True
+                    engine.status["poeng"] -= 50
+                else:
+                    print("Det er ikke noen andre kolber som ser interessante ut.")
+            if obj == "skrin":
+                print("Du plukker opp skrinet, som virker relativt lett. Låsen ser mye nyere ut enn selve skrinet. Når du rister på det hører du at det er noe inni.")
+
+        elif verb == "bruk" and isinstance(obj, tuple):
+            item, target = obj
+            if item == "brekkjern" and target == "skrin":
+                if not engine.inventar["har_nøkkel"]:
+                    print("Du presser brekkjernet inn under hengelåsen og rykker til. Hengelåsen faller til gulvet, og lokket spretter opp. Ut faller en nøkkel, som du plukker opp.")
+                    engine.inventar["har_nøkkel"] = True
+                else:
+                    print("Tror ikke det er så mye mer brekkjernet kan gjøre med dette gamle skrinet...")
+            else:
+                print(engine.ugyldig)
+        else:
+            print(engine.ugyldig)

--- a/game/savegame.json
+++ b/game/savegame.json
@@ -10,12 +10,12 @@
         "rom7": true,
         "rom8": true,
         "rom9": true,
-        "rom10": false,
-        "rom11": false,
-        "rom12": false,
-        "rom13": false,
-        "kjeller2_1": false,
-        "kjeller2_2": false
+        "rom10": true,
+        "rom11": true,
+        "rom12": true,
+        "rom13": true,
+        "kjeller2_1": true,
+        "kjeller2_2": true
     },
     "status": {
         "har_hammer": true,
@@ -39,5 +39,5 @@
         "luke_nøkkel1": false,
         "luke_nøkkel2": false
     },
-    "rom": "rom5"
+    "rom": "kjeller2_1"
 }

--- a/game/savegame.json
+++ b/game/savegame.json
@@ -1,0 +1,37 @@
+{
+    "besøkt": {
+        "rom1": true,
+        "rom2": true,
+        "rom3": false,
+        "rom4": false,
+        "gang1": false,
+        "rom5": false,
+        "rom6": false,
+        "rom7": false,
+        "rom8": false,
+        "rom9": false,
+        "rom10": false,
+        "rom11": false
+    },
+    "status": {
+        "har_hammer": true,
+        "rom2_skap": false,
+        "tall1": false,
+        "tall2": false,
+        "tall3": false,
+        "åpen_ventil": false,
+        "bøtte": false,
+        "åpen_hylle": false,
+        "hengelås": false,
+        "helse": 3,
+        "poeng": 10
+    },
+    "inventar": {
+        "brekkjern": false,
+        "har_nøkkel": false,
+        "falsk_nøkkel": false,
+        "glødende_sopp": false,
+        "kart": false
+    },
+    "rom": "rom2"
+}

--- a/game/savegame.json
+++ b/game/savegame.json
@@ -2,16 +2,20 @@
     "besøkt": {
         "rom1": true,
         "rom2": true,
-        "rom3": false,
-        "rom4": false,
-        "gang1": false,
-        "rom5": false,
-        "rom6": false,
-        "rom7": false,
-        "rom8": false,
-        "rom9": false,
+        "rom3": true,
+        "rom4": true,
+        "gang1": true,
+        "rom5": true,
+        "rom6": true,
+        "rom7": true,
+        "rom8": true,
+        "rom9": true,
         "rom10": false,
-        "rom11": false
+        "rom11": false,
+        "rom12": false,
+        "rom13": false,
+        "kjeller2_1": false,
+        "kjeller2_2": false
     },
     "status": {
         "har_hammer": true,
@@ -21,17 +25,19 @@
         "tall3": false,
         "åpen_ventil": false,
         "bøtte": false,
-        "åpen_hylle": false,
+        "åpen_hylle": true,
         "hengelås": false,
         "helse": 3,
-        "poeng": 10
+        "poeng": 110
     },
     "inventar": {
         "brekkjern": false,
         "har_nøkkel": false,
         "falsk_nøkkel": false,
         "glødende_sopp": false,
-        "kart": false
+        "kart": true,
+        "luke_nøkkel1": false,
+        "luke_nøkkel2": false
     },
-    "rom": "rom2"
+    "rom": "rom5"
 }


### PR DESCRIPTION
## [1.4.0] - 2025-09-08
### Lagt til
- Introdusert et poengsystem.
    - Forskjellige handlinger gjennom spillet vil gi spilleren varierende antall poeng.
    - Poengene printes kun når spilleren dør eller fullfører spillet.
- Fire nye rom er også lagt til, rom12, rom13, kjeller2_1 og kjeller2_2.

### Endret
- Lagt til en `se`-beskrivelse for ventil i rom 4 og rom 8 etter `status["åpen_ventil"]` er flippet.
- Oppdatert rombeskrivelse i rom6, rom8 (inkl. etter endring), rom9, rom10 og rom11 til å inkludere alle mulige utganger.

### Fikset
- Fikset logikken slik at den ekte nøkkelen brukes først dersom spiller har både ekte og falsk nøkkel i inventar i rom 4.
- Skrivefeil: "dunts" -> "dunst"

### Fjernet
- Det var teknisk sett mulig å bruke brekkjernet på vinduet i rom1, selv om spilleren aldri kan nå rom1 med brekkjernet i inventaret. Fjernet den relevante koden.